### PR TITLE
Changed MD_UISwitch_Digital pins to be constant

### DIFF
--- a/src/MD_UISwitch.h
+++ b/src/MD_UISwitch.h
@@ -444,7 +444,7 @@ public:
   * \param pinCount  the number of pin in the pins[] array
   * \param onState   the state for the switch to be active
   */
-  MD_UISwitch_Digital(uint8_t *pins, uint8_t pinCount, uint8_t onState = KEY_ACTIVE_STATE) :
+  MD_UISwitch_Digital(const uint8_t *pins, uint8_t pinCount, uint8_t onState = KEY_ACTIVE_STATE) :
     _pins(pins), _pinCount(pinCount), _onState(onState) {};
 
   /**
@@ -483,10 +483,10 @@ public:
   /** @} */
 
 protected:
-  uint8_t   _pinSimple; ///< pin number for simple pins
-  uint8_t   *_pins;     ///< pointer to data for one or more pins
-  uint8_t   _pinCount;  ///< number of pins defined
-  uint8_t   _onState;   ///< digital state for ON
+  uint8_t       _pinSimple; ///< pin number for simple pins
+  const uint8_t *_pins;     ///< pointer to data for one or more pins
+  uint8_t       _pinCount;  ///< number of pins defined
+  uint8_t       _onState;   ///< digital state for ON
 };
 
 /**


### PR DESCRIPTION
I added a `const` attribute to the digital pin array-
it doesn't change by the library so it must be declared as pointer to constant array.

Now the MD_UISwitch_Example.ino works when `#define TEST_DIGITAL_ARRAY 1`-
Because it declares [`const uint8_t DIGITAL_SWITCH_PINS[]`](https://github.com/MajicDesigns/MD_UISwitch/blob/main/examples/MD_UISwitch_Example/MD_UISwitch_Example.ino#L33) the right way.

Before this commit it won't complie:
`invalid conversion from 'const uint8_t* {aka const unsigned char*}' to 'uint8_t {aka unsigned char}'`.